### PR TITLE
 Use `text` as dependency in `remember` for `annotatedString`

### DIFF
--- a/autolinktext/src/commonMain/kotlin/sh/calvin/autolinktext/AnnotatedString+autoLinkText.kt
+++ b/autolinktext/src/commonMain/kotlin/sh/calvin/autolinktext/AnnotatedString+autoLinkText.kt
@@ -40,7 +40,7 @@ fun AnnotatedString.Companion.rememberAutoLinkText(
         }
             .getAllMatches(text)
     }
-    val annotatedString = remember(matches) {
+    val annotatedString = remember(text, matches) {
         matches.annotateString(text)
     }
 


### PR DESCRIPTION
The `annotatedString` now depends on `text` in the `remember` function. This ensures that the annotated string is recomputed when the `text` changes, in addition to when `matches` changes.